### PR TITLE
Se agregaron permisos adecuados para modificar releases en GitHub Act…

### DIFF
--- a/.github/workflows/push-in-master.yml
+++ b/.github/workflows/push-in-master.yml
@@ -5,6 +5,9 @@ on:
         branches:
             - master
 
+permissions:
+    contents: write
+
 jobs:
     build_release:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Se añadieron los permisos `contents: write` en el workflow "Build y Despliegue en Master" para que el GITHUB_TOKEN pueda eliminar y crear releases correctamente.

El error ocurría porque, al separar los workflows, no se especificaron permisos explícitos, lo que resultó en una restricción predeterminada que impedía la eliminación del release "latest". Esto causaba un error 403 al intentar acceder a la API de GitHub.

Con esta corrección, el workflow puede gestionar el release sin problemas, manteniendo el mismo enlace al APK en el README.