### PR TITLE
Update Gradle and Android Gradle Plugin versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 accompanistPager = "0.28.0"
 accompanistSystemuicontroller = "0.30.1"
-agp = "8.9.0-alpha01"
+agp = "8.10.0-alpha04"
 byteBuddy = "1.14.6"
 kotlin = "2.0.0"
 coreKtx = "1.15.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Jan 21 20:46:01 COT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Updated Gradle wrapper to version 8.11.1.
- Updated Android Gradle Plugin to version 8.10.0-alpha04.
- Android Lint in version 8.1.0-alpha04 contains bytecode targeting JVM 17.